### PR TITLE
Fix label selectors by prioritizing in-built labels

### DIFF
--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -90,7 +90,12 @@ local render_component(configuredStack, component, prefix) =
 
   {
     ['%d_%s_%s' % [ prefix, component, name ]]: kp[name] {
-      metadata+: commonMetadata,
+      metadata:
+        commonMetadata
+        +
+        com.makeMergeable(
+          com.getValueOrDefault(kp[name], 'metadata', {})
+        ),
     }
     for name in std.objectFields(kp)
   };

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRole.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.26.0
   name: prometheus-default-instance
 rules:

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.26.0
   name: prometheus-default-instance
 roleRef:

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_podDisruptionBudget.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_podDisruptionBudget.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.26.0
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheus.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheus.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.26.0
     prometheus: default-instance
   name: default-instance

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheusRule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.26.0
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleBindingConfig.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleBindingConfig.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.26.0
   name: prometheus-default-instance-config
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleConfig.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleConfig.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.26.0
   name: prometheus-default-instance-config
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_service.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.26.0
     prometheus: default-instance
   name: prometheus-default-instance

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.26.0
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.26.0
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_alertmanager.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_alertmanager.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.21.0
   name: alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_podDisruptionBudget.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_podDisruptionBudget.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.21.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_prometheusRule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.21.0
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_secret.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_secret.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.21.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_service.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.21.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceAccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.21.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.21.0
   name: alertmanager
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/40_grafana_dashboardDatasources.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/40_grafana_dashboardDatasources.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 7.5.4
   name: grafana-datasources
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/40_grafana_dashboardSources.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/40_grafana_dashboardSources.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 7.5.4
   name: grafana-dashboards
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/40_grafana_deployment.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/40_grafana_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 7.5.4
   name: grafana
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/40_grafana_service.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/40_grafana_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 7.5.4
   name: grafana
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/40_grafana_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/40_grafana_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 7.5.4
   name: grafana
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRole.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.1.2
   name: nodeexporter-default-instance
 rules:

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.1.2
   name: nodeexporter-default-instance
 roleRef:

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_daemonset.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_daemonset.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.1.2
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_prometheusRule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.1.2
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_service.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.1.2
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.1.2
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.1.2
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_configuration.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_configuration.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.18.0
   name: blackbox-exporter-configuration
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_deployment.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.18.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_service.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.18.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.18.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_prometheusRule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kube-prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     prometheus: default-instance
     role: alert-rules
   name: kubernetes-monitoring-rules

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_apiService.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_apiService.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
   name: v1beta1.metrics.k8s.io
 spec:

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRole.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
   name: prometheusadapter-default-instance
 rules:

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleAggregatedMetricsReader.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleAggregatedMetricsReader.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
   name: prometheusadapter-default-instance
 roleRef:

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBindingDelegator.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBindingDelegator.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
   name: resource-metrics:system:auth-delegator
 roleRef:

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleServerResources.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleServerResources.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
   name: resource-metrics-server-resources
 rules:

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_configMap.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_configMap.yaml
@@ -27,7 +27,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
   name: adapter-config
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_deployment.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_podDisruptionBudget.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_podDisruptionBudget.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_roleBindingAuthReader.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_roleBindingAuthReader.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
   name: resource-metrics-auth-reader
   namespace: kube-system

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_service.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.8.4
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRole.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.0.0
   name: kubestatemetrics-default-instance
 rules:

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.0.0
   name: kubestatemetrics-default-instance
 roleRef:

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_deployment.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.0.0
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_prometheusRule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.0.0
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_service.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.0.0
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.0.0
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.20/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.0.0
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRole.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.29.1
   name: prometheus-default-instance
 rules:

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.29.1
   name: prometheus-default-instance
 roleRef:

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_podDisruptionBudget.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_podDisruptionBudget.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.29.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheus.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheus.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.29.1
     prometheus: default-instance
   name: default-instance

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheusRule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.29.1
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleBindingConfig.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleBindingConfig.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.29.1
   name: prometheus-default-instance-config
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleConfig.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleConfig.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.29.1
   name: prometheus-default-instance-config
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_service.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.29.1
     prometheus: default-instance
   name: prometheus-default-instance

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.29.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.29.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_alertmanager.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_alertmanager.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.22.2
   name: alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_podDisruptionBudget.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_podDisruptionBudget.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.22.2
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_prometheusRule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.22.2
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_secret.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_secret.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.22.2
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_service.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.22.2
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceAccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.22.2
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.22.2
   name: alertmanager
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/40_grafana_dashboardDatasources.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/40_grafana_dashboardDatasources.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 8.1.1
   name: grafana-datasources
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/40_grafana_dashboardSources.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/40_grafana_dashboardSources.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 8.1.1
   name: grafana-dashboards
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/40_grafana_deployment.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/40_grafana_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 8.1.1
   name: grafana
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/40_grafana_service.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/40_grafana_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 8.1.1
   name: grafana
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/40_grafana_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/40_grafana_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 8.1.1
   name: grafana
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRole.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.2.2
   name: nodeexporter-default-instance
 rules:

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.2.2
   name: nodeexporter-default-instance
 roleRef:

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_daemonset.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_daemonset.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.2.2
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_prometheusRule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.2.2
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_service.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.2.2
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.2.2
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.2.2
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_configuration.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_configuration.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter-configuration
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_deployment.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_service.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_prometheusRule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kube-prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     prometheus: default-instance
     role: alert-rules
   name: kubernetes-monitoring-rules

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_apiService.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_apiService.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
   name: v1beta1.metrics.k8s.io
 spec:

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRole.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
   name: prometheusadapter-default-instance
 rules:

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleAggregatedMetricsReader.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleAggregatedMetricsReader.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
   name: prometheusadapter-default-instance
 roleRef:

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBindingDelegator.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBindingDelegator.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
   name: resource-metrics:system:auth-delegator
 roleRef:

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleServerResources.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleServerResources.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
   name: resource-metrics-server-resources
 rules:

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_configMap.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_configMap.yaml
@@ -30,7 +30,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
   name: adapter-config
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_deployment.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_podDisruptionBudget.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_podDisruptionBudget.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_roleBindingAuthReader.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_roleBindingAuthReader.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
   name: resource-metrics-auth-reader
   namespace: kube-system

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_service.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.0
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRole.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.1.1
   name: kubestatemetrics-default-instance
 rules:

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.1.1
   name: kubestatemetrics-default-instance
 roleRef:

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_deployment.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.1.1
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_prometheusRule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.1.1
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_service.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.1.1
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.1.1
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.21/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.1.1
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRole.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRole.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRoleBinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_podDisruptionBudget.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_podDisruptionBudget.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheus.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheus.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheusRule.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleBindingConfig.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleBindingConfig.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance-config
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleConfig.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleConfig.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance-config
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_service.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceAccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceMonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_alertmanager.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_alertmanager.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
   name: alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_podDisruptionBudget.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_podDisruptionBudget.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_prometheusRule.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_secret.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_secret.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_service.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceAccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceMonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_config.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_config.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 8.3.3
   name: grafana-config
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_dashboardDatasources.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_dashboardDatasources.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 8.3.3
   name: grafana-datasources
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_dashboardSources.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_dashboardSources.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 8.3.3
   name: grafana-dashboards
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_deployment.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 8.3.3
   name: grafana
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_service.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 8.3.3
   name: grafana
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 8.3.3
   name: grafana
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/40_grafana_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: grafana-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 8.3.3
   name: grafana
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRole.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_daemonset.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_daemonset.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_prometheusRule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_service.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_configuration.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_configuration.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter-configuration
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_deployment.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_service.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_prometheusRule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kube-prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     prometheus: default-instance
     role: alert-rules
   name: kubernetes-monitoring-rules

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorApiserver.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorApiserver.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: apiserver
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
   name: kube-apiserver
   namespace: syn-prometheus
 spec:

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorCoreDNS.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorCoreDNS.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: coredns
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
   name: coredns
   namespace: syn-prometheus
 spec:

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorKubeControllerManager.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorKubeControllerManager.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kube-controller-manager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
   name: kube-controller-manager
   namespace: syn-prometheus
 spec:

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorKubeScheduler.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorKubeScheduler.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kube-scheduler
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
   name: kube-scheduler
   namespace: syn-prometheus
 spec:

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorKubelet.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorKubelet.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubelet
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
   name: kubelet
   namespace: syn-prometheus
 spec:

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_apiService.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_apiService.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: v1beta1.metrics.k8s.io
 spec:

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRole.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleAggregatedMetricsReader.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleAggregatedMetricsReader.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBindingDelegator.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBindingDelegator.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: resource-metrics:system:auth-delegator
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleServerResources.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleServerResources.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: resource-metrics-server-resources
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_configMap.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_configMap.yaml
@@ -30,7 +30,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: adapter-config
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_deployment.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_podDisruptionBudget.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_podDisruptionBudget.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_roleBindingAuthReader.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_roleBindingAuthReader.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: resource-metrics-auth-reader
   namespace: kube-system

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_service.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRole.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
   name: kubestatemetrics-default-instance
 rules:

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRoleBinding.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
   name: kubestatemetrics-default-instance
 roleRef:

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_deployment.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_prometheusRule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_service.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceAccount.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceMonitor.yaml
+++ b/tests/golden/kubernetes_1.22/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRole.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRole.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRoleBinding.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_clusterRoleBinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_podDisruptionBudget.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_podDisruptionBudget.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheus.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheus.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheusRule.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_prometheusRule.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleBindingConfig.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleBindingConfig.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance-config
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleConfig.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_roleConfig.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance-config
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_service.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceAccount.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceAccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceMonitor.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/20_prometheus_serviceMonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.32.1
   name: prometheus-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_alertmanager.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_alertmanager.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
   name: alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_podDisruptionBudget.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_podDisruptionBudget.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_prometheusRule.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_prometheusRule.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_secret.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_secret.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_service.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceAccount.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceAccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceMonitor.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/30_alertmanager_serviceMonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: alertmanager-default-instance
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: alertmanager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
   name: alertmanager-alertmanager-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRole.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRoleBinding.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_daemonset.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_daemonset.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_prometheusRule.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_prometheusRule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_service.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceAccount.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceMonitor.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/50_nodeExporter_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: nodeexporter-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.3.1
   name: nodeexporter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_clusterRoleBinding.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_configuration.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_configuration.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter-configuration
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_deployment.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_service.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_serviceAccount.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_serviceMonitor.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/60_blackboxExporter_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_prometheusRule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kube-prometheus
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     prometheus: default-instance
     role: alert-rules
   name: kubernetes-monitoring-rules

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorApiserver.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorApiserver.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: apiserver
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
   name: kube-apiserver
   namespace: syn-prometheus
 spec:

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorCoreDNS.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorCoreDNS.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: coredns
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
   name: coredns
   namespace: syn-prometheus
 spec:

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorKubeControllerManager.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorKubeControllerManager.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kube-controller-manager
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
   name: kube-controller-manager
   namespace: syn-prometheus
 spec:

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorKubeScheduler.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorKubeScheduler.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kube-scheduler
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
   name: kube-scheduler
   namespace: syn-prometheus
 spec:

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorKubelet.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/70_kubernetesControlPlane_serviceMonitorKubelet.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubelet
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
   name: kubelet
   namespace: syn-prometheus
 spec:

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_apiService.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_apiService.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: v1beta1.metrics.k8s.io
 spec:

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRole.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleAggregatedMetricsReader.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleAggregatedMetricsReader.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBinding.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBindingDelegator.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleBindingDelegator.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: resource-metrics:system:auth-delegator
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleServerResources.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_clusterRoleServerResources.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: resource-metrics-server-resources
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_configMap.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_configMap.yaml
@@ -30,7 +30,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: adapter-config
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_deployment.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_podDisruptionBudget.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_podDisruptionBudget.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_roleBindingAuthReader.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_roleBindingAuthReader.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: resource-metrics-auth-reader
   namespace: kube-system

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_service.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceAccount.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceMonitor.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/80_prometheusAdapter_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheusadapter-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRole.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
   name: kubestatemetrics-default-instance
 rules:

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRoleBinding.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_clusterRoleBinding.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
   name: kubestatemetrics-default-instance
 roleRef:

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_deployment.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_prometheusRule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
     prometheus: default-instance
     role: alert-rules

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_service.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceAccount.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceAccount.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus

--- a/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceMonitor.yaml
+++ b/tests/golden/openshift/syn-kube-prometheus/syn-kube-prometheus/90_kubeStateMetrics_serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: kubestatemetrics-default-instance
-    app.kubernetes.io/part-of: syn
+    app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.3.0
   name: kubestatemetrics-default-instance
   namespace: syn-prometheus


### PR DESCRIPTION
With the current setup we for example break the service monitor of Prometheus itself. Instead of trying to fix all selectors I think we should prioritize in-built labels

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
